### PR TITLE
reduce logging on running pods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install shellcheck
         run: brew install shellcheck

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,18 +19,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@v2.1.0
 
       - name: Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -39,14 +39,14 @@ jobs:
 
       - name: Login to DockerHub
         # if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v3.4.1
+        uses: docker/metadata-action@v4
         with:
           images: |
             ${{ secrets.DOCKER_HUB_ACCOUNT }}/${{ secrets.DOCKER_HUB_IMAGE }}
@@ -60,7 +60,7 @@ jobs:
             type=sha
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
         uses: actions/cache@v3

--- a/run.sh
+++ b/run.sh
@@ -107,5 +107,5 @@ while true; do
 	done < $PODS_DISCOVERED_FILE
 	echo "Waiting $WAIT_TIME seconds; timestamp: $(date -u +%Y%m%d%H%M%S)"
 	echo ""
-	sleep $WAIT_TIME
+	sleep "$WAIT_TIME"
 done

--- a/run.sh
+++ b/run.sh
@@ -67,9 +67,6 @@ jq_program='
 
 jq -r "$jq_program" < $POD_FILE > $PODS_DISCOVERED_FILE
 
-echo "Running pods: "
-awk '/Running/ {print $1}' < $PODS_DISCOVERED_FILE
-echo ""
 }
 
 


### PR DESCRIPTION
Reduce the number of logs sent due to deployments by the container. 
It will drastically remove a lot of lines as it will not print all the running pods